### PR TITLE
Duplicate course fix

### DIFF
--- a/frontend/src/config.json
+++ b/frontend/src/config.json
@@ -1,3 +1,3 @@
 {
-  "max_courses": 3
+  "max_courses": 7
 }

--- a/frontend/src/hooks/useSyllabusWrapperLogic.ts
+++ b/frontend/src/hooks/useSyllabusWrapperLogic.ts
@@ -1,10 +1,11 @@
 import { useEffect, useRef } from "react";
 import { handleNext, handleBack } from "../components/Button/ButtonLogic";
-import { createSaveAndExitHandler, createPreviewHandler } from "../utils/handlers/previewExitFactory";
+import {createPreviewHandler } from "../utils/handlers/previewExitFactory";
 import type { NavigateFunction } from "react-router-dom";
 import saveData from "../services/processData";
 import { loadCourseData } from "../utils/loadCourseData";
 import { useModalFactory } from "../utils/useModalFactory"; 
+import { saveAndExitHandler } from "../utils/handlers/SaveAndExitHandler";
 
 interface SyllabusWrapperLogicResult {
   modal: ReturnType<typeof useModalFactory>;
@@ -96,12 +97,13 @@ export function useSyllabusWrapperLogic(
     handleBackClick,
     handleNextClick,
     handleSave,
-    handleSaveAndExit: createSaveAndExitHandler(formData, navigate, {
-      setVisible: modal.hide,
-      setStatus: () => {},
-      setTitle: () => {},
-      setMessage: () => {},
-    }),
+    handleSaveAndExit: () =>
+      saveAndExitHandler({
+        formData,
+        containerRef: containerRef as React.RefObject<HTMLDivElement>,
+        modal,
+        navigate,
+      }),
     handlePreviewClick: createPreviewHandler(formData, {
       setVisible: modal.hide,
       setStatus: () => {},

--- a/frontend/src/screens/CoursePage/CoursePage.tsx
+++ b/frontend/src/screens/CoursePage/CoursePage.tsx
@@ -175,6 +175,10 @@ const CoursePage: React.FC = () => {
                                 </button>
                             </div>
                         </div>
+
+                        <div className='course-limit-info'>
+                            <p> <b>Please Note:</b> You can store up to {maxCourses} courses a time. If you want to create more courses, you will need to delete another course. Editing an existing syllabus will overwrite the previously entered information. If you use the duplicate function, you will be able to preserve the original version and create a new version of the syllabus.</p>
+                        </div>
                         
                         {isAtMaxCapacity && (
                             <div className="max-courses-message">

--- a/frontend/src/services/course/courseService.ts
+++ b/frontend/src/services/course/courseService.ts
@@ -148,3 +148,20 @@ export const duplicateCourse = (
         data: {course_id},
     })();
 };
+
+export const previewSyllabus = async (course_id: string): Promise<Blob | null> => {
+    return await createApiCaller<Blob>({
+        method: "POST",
+        url: "/preview/",
+        data: { course_id },
+        responseType: "blob",
+    })();
+};
+
+export const logoutUser = async () => {
+    return await createApiCaller<void>({
+        method: "GET",
+        url: "/logout/",
+    })();
+};
+

--- a/frontend/src/utils/handlers/SaveAndExitHandler.ts
+++ b/frontend/src/utils/handlers/SaveAndExitHandler.ts
@@ -1,0 +1,46 @@
+import { createNewCourse
+ } from "../../services/course/courseService";
+ import saveData from "../../services/processData";
+
+export async function saveAndExitHandler({
+  formData,
+  containerRef,
+  modal,
+  navigate,
+}: {
+  formData: Record<string, string>,
+  containerRef: React.RefObject<HTMLDivElement>,
+  modal: any,
+  navigate: (path: string) => void,
+}) {
+  modal.showRedirect("Saving & Exiting", "Hold on, we're saving and redirecting you...", "loading");
+
+  let course_id = formData["course_id"] || localStorage.getItem("currentCourseId");
+  let dataToSave = { ...formData };
+
+  if (!course_id) {
+    const result = await createNewCourse(dataToSave);
+    if (!result?.course_id) {
+      modal.showError("Failed to create course");
+      setTimeout(() => modal.hide(), 2500);
+      return;
+    }
+    course_id = result.course_id;
+    dataToSave["course_id"] = course_id;
+    localStorage.setItem("currentCourseId", course_id);
+  }
+  localStorage.setItem("currentCourseId", course_id);
+  localStorage.setItem("currentCourseData", JSON.stringify({ ...dataToSave, course_id }));
+
+  try {
+    await saveData(containerRef);
+    modal.showRedirect("Saved & Exiting", "Redirecting you to My Courses Home Page...", "success");
+    setTimeout(() => {
+      modal.hide();
+      navigate("/course-page");
+    }, 1500);
+  } catch (err: any) {
+    modal.showError(err?.message || "An unexpected error occurred.");
+    setTimeout(() => modal.hide(), 2500);
+  }
+}

--- a/frontend/src/utils/handlers/previewExitFactory.ts
+++ b/frontend/src/utils/handlers/previewExitFactory.ts
@@ -1,6 +1,6 @@
 // src/utils/handlers/previewExitFactory.ts
 
-import { saveToBackend, logoutUser, previewSyllabus } from "../../services/TestServices/syllabusService";
+import { previewSyllabus, updateCourseValues } from "../../services/course/courseService";
 import { createNewCourse } from "../../services/course/courseService";
 
 type ModalControls = {
@@ -65,7 +65,7 @@ export const createSaveHandler = (
 
         localStorage.setItem("currentCourseData", JSON.stringify({ ...mappedData, course_id }));
 
-        const result = await saveToBackend(course_id, mappedData);
+        const result = await updateCourseValues(course_id, mappedData);
         if (result !== null) {
             modal.setStatus("success");
             modal.setTitle("Saved!");
@@ -121,7 +121,7 @@ export const createSaveAndExitHandler = (
             localStorage.setItem("currentCourseData", JSON.stringify(mappedData));
         }
 
-        const saveResult = await saveToBackend(course_id, mappedData);
+        const saveResult = await updateCourseValues(course_id, mappedData);
         if (saveResult !== null) {
             modal.setStatus("success");
             modal.setTitle("Saved & Exiting");
@@ -188,7 +188,7 @@ export const createPreviewHandler = (
 
         localStorage.setItem("currentCourseData", JSON.stringify(mappedData));
 
-        const saveResult = await saveToBackend(course_id, mappedData);
+        const saveResult = await updateCourseValues(course_id, mappedData);
         if (saveResult !== null) {
             const blob = await previewSyllabus(course_id);
             if (blob) {


### PR DESCRIPTION
This PR Fixes the Duplicate Course glitch on Save and Exit.

## Changes
- Created a `SaveAndExitHandler.ts`.
- Moved all API calls to the `courseService.ts`.
- Updates CourseDetails to display a standard message if user is not at max course capacity, if is at max course capacity then presents alert.
- Updated Course numbers allowed to 7 for testing.
- Saving and Exiting uses the useRef similar to Save